### PR TITLE
Ignore run_exports for icu module

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,8 @@ build:
     # remove symbols at minor versions.
     #    https://abi-laboratory.pro/tracker/timeline/libxml2/
     - {{ pin_subpackage('libxml2', max_pin='x.x') }}
+  ignore_run_exports:
+    - icu
 
 requirements:
   build:


### PR DESCRIPTION
@katietz @tobijk @chenghlee @remkade

Although the latest version of libxml2 has all its CVEs addressed, the run_exports in its meta.yaml pins users to using an older icu that has many CVEs. This PR removes this pinning, which allows users to install icu 68.1, free from any CVEs.

```
libxml2 2.9.14 h74e7548_0
-------------------------
file name   : libxml2-2.9.14-h74e7548_0.conda
name        : libxml2
version     : 2.9.14
build       : h74e7548_0
build number: 0
size        : 718 KB
license     : MIT
subdir      : linux-64
url         : https://repo.anaconda.com/pkgs/main/linux-64/libxml2-2.9.14-h74e7548_0.conda
md5         : 2eafeb1cb5f00b034d150f3d70436e52
timestamp   : 2022-05-26 06:26:58 UTC
dependencies:
  - icu >=58.2,<59.0a0
  - libgcc-ng >=7.5.0
  - xz >=5.2.5,<6.0a0
  - zlib >=1.2.12,<1.3.0a0
```