### PR TITLE
initial build for `libxml2` version `2.10.3`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,12 +43,12 @@ requirements:
 test:
   files:
     - test.xml
-  requires:
-    - conda-build
+#  requires:
+#    - conda-build
   commands:
     - xmllint test.xml
-    - conda inspect linkages -p $PREFIX libxml2  # [not win]
-    - conda inspect objects -p $PREFIX libxml2  # [osx]
+#    - conda inspect linkages -p $PREFIX libxml2  # [not win]
+#    - conda inspect objects -p $PREFIX libxml2  # [osx]
 
 about:
   home: https://gitlab.gnome.org/GNOME/libxml2/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,11 +28,11 @@ requirements:
     - m2-patch    # [win]
   host:
     - icu {{icu}}         # [not win]
-    - libiconv    # [not linux]
+    - libiconv 1.16   # [not linux]
     - xz {{xz}}         # [not win]
     - zlib {{zlib}}
   run:
-    - libiconv   # [not linux]
+    - libiconv 1.16  # [not linux]
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,25 +20,21 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - autoconf ==2.71   # [not win]
-    - automake ==1.16.5   # [not win]
-    - libtool  ==2.4.6   # [not win]
+    - autoconf   # [not win]
+    - automake   # [not win]
+    - libtool   # [not win]
     - pkg-config  # [not win]
     - make      # [not win]
     - m2-patch    # [win]
-    - patch ==2.7.6      # [not win]
+    - patch      # [not win]
   host:
-    # solve icu dependency conflicts
-    - icu ==68.1         # [not win]
+    - icu         # [not win]
     # test to resolve dependency conflict
-#    - libiconv    # [not linux]
-    - libiconv ==1.16   # [not linux]
-#    - xz          # [not win]
-    - xz ==5.2.10
-#    - zlib
-    - zlib ==1.2.13
+    - libiconv    # [not linux]
+    - xz          # [not win]
+    - zlib
   run:
-    - libiconv ==1.16   # [not linux]
+    - libiconv   # [not linux]
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,14 +29,14 @@ requirements:
     - patch       # [not win]
   host:
     # solve icu dependency conflicts
-    - icu=68.1         # [not win]
+    - icu ==68.1         # [not win]
     # test to resolve dependency conflict
 #    - libiconv    # [not linux]
     - libiconv =1.16   # [not linux]
 #    - xz          # [not win]
-    - xz =5.2.10
+    - xz ==5.2.10
 #    - zlib
-    - zlib =1.2.13
+    - zlib ==1.2.13
   run:
     - libiconv    # [not linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,12 +28,12 @@ requirements:
     - m2-patch    # [win]
     - patch       # [not win]
   host:
-    - icu         # [not win]
+    # solve icu dependency conflicts
+    - icu =68.1         # [not win]
     - libiconv    # [not linux]
-#    - xz          # [not win]
+    - xz          # [not win]
     - xz >=5.2.5
-#    - zlib
-    - zlib >=1.2.11
+    - zlib
   run:
     - libiconv    # [not linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,8 +30,10 @@ requirements:
   host:
     - icu         # [not win]
     - libiconv    # [not linux]
-    - xz          # [not win]
-    - zlib
+#    - xz          # [not win]
+    - xz >=5.2.5
+#    - zlib
+    - zlib >=1.2.11
   run:
     - libiconv    # [not linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,25 +20,25 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - autoconf    # [not win]
-    - automake    # [not win]
-    - libtool     # [not win]
+    - autoconf ==2.71   # [not win]
+    - automake ==1.16.5   # [not win]
+    - libtool  ==2.4.6   # [not win]
     - pkg-config  # [not win]
-    - make        # [not win]
+    - make      # [not win]
     - m2-patch    # [win]
-    - patch       # [not win]
+    - patch ==2.7.6      # [not win]
   host:
     # solve icu dependency conflicts
     - icu ==68.1         # [not win]
     # test to resolve dependency conflict
 #    - libiconv    # [not linux]
-    - libiconv =1.16   # [not linux]
+    - libiconv ==1.16   # [not linux]
 #    - xz          # [not win]
     - xz ==5.2.10
 #    - zlib
     - zlib ==1.2.13
   run:
-    - libiconv    # [not linux]
+    - libiconv ==1.16   # [not linux]
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,10 +27,10 @@ requirements:
     - make      # [not win]
     - m2-patch    # [win]
   host:
-    - icu         # [not win]
+    - icu {{icu}}         # [not win]
     - libiconv    # [not linux]
-    - xz          # [not win]
-    - zlib
+    - xz {{xz}}         # [not win]
+    - zlib {{zlib}}
   run:
     - libiconv   # [not linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.9.14" %}
+{% set version = "2.10.3" %}
 
 package:
   name: libxml2
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://gitlab.gnome.org/GNOME/libxml2/-/archive/v{{ version }}/libxml2-v{{ version }}.tar.gz
-  sha256: 80efe9e6b48f8aa7b9b0c47be427e2ef2dbfb2999124220ffbc0f43ca6adb98c
+  sha256: 497f12e34790d407ec9e2a190d576c0881a1cd78ff3c8991d1f9e40281a5ff57
   patches:
     - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,11 +29,14 @@ requirements:
     - patch       # [not win]
   host:
     # solve icu dependency conflicts
-    - icu =68.1         # [not win]
-    - libiconv    # [not linux]
-    - xz          # [not win]
-    - xz >=5.2.5
-    - zlib
+    - icu=68.1         # [not win]
+    # test to resolve dependency conflict
+#    - libiconv    # [not linux]
+    - libiconv =1.16   # [not linux]
+#    - xz          # [not win]
+    - xz =5.2.10
+#    - zlib
+    - zlib =1.2.13
   run:
     - libiconv    # [not linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - xz {{xz}}         # [not win]
     - zlib {{zlib}}
   run:
-    - libiconv 1.16  # [not linux]
+    - libiconv  # [not linux]
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - patch      # [not win]
   host:
     - icu         # [not win]
-    # test to resolve dependency conflict
     - libiconv    # [not linux]
     - xz          # [not win]
     - zlib
@@ -39,12 +38,8 @@ requirements:
 test:
   files:
     - test.xml
-#  requires:
-#    - conda-build
   commands:
     - xmllint test.xml
-#    - conda inspect linkages -p $PREFIX libxml2  # [not win]
-#    - conda inspect objects -p $PREFIX libxml2  # [osx]
 
 about:
   home: https://gitlab.gnome.org/GNOME/libxml2/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,8 @@ package:
 source:
   url: https://gitlab.gnome.org/GNOME/libxml2/-/archive/v{{ version }}/libxml2-v{{ version }}.tar.gz
   sha256: 497f12e34790d407ec9e2a190d576c0881a1cd78ff3c8991d1f9e40281a5ff57
-  patches:
-    - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch
+  patches:  # [win]
+    - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch  # [win]
 
 build:
   number: 0
@@ -26,7 +26,6 @@ requirements:
     - pkg-config  # [not win]
     - make      # [not win]
     - m2-patch    # [win]
-    - patch      # [not win]
   host:
     - icu         # [not win]
     - libiconv    # [not linux]


### PR DESCRIPTION

`libxml2` version `2.10.3`
1. - [X] Check the upstream
    https://gitlab.gnome.org/GNOME/libxml2/-/tree/v2.10.3
2. - [X] Check the pinnings
3. - [X] Check the changelogs
    https://gitlab.gnome.org/GNOME/libxml2/-/blob/v2.10.3/NEWS
4. - [X] Additional research
    https://github.com/conda-forge/libxml2-feedstock/issues
    
    There are currently 2 Open issues mentioned in the upstream.

    There are open issues with activating and deactivating scripts.

    https://github.com/conda-forge/libxml2-feedstock/issues/86

    And issues with the ICU and linked to too many things

    https://github.com/conda-forge/libxml2-feedstock/issues/41

5. - [X] Verify the `dev_url`
    https://gitlab.gnome.org/GNOME/libxml2/
6. - [X] Verify the `doc_url`
    https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home
7. - [X] License is `spdx` compliant
    MIT
8. - [X] License family is present
    MIT
9. - [X] Verify that the `build_number` is correct
10. - [X] Verify if the package needs `setuptools`
      
11. - [X] Verify if the package needs `wheel`
    
12. - [X] `pip` in the test section
    
13. - [X] Veriy the test section
14. - [X] Verify if the package is `architecture specific` or `Noarch`
15. - [X] Verify that private modules are not mentioned on the recipe For example: (_private_module)
 
Results:
- 
 
 
Based on the research findings and the results we can conclude
that it is ok to update `libxml2` to version `2.10.3`

We however must keep an eye on potential open issues.

