### PR TITLE
Update to 2.10.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.10.3" %}
+{% set version = "2.10.4" %}
 
 package:
   name: libxml2
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://gitlab.gnome.org/GNOME/libxml2/-/archive/v{{ version }}/libxml2-v{{ version }}.tar.gz
-  sha256: 497f12e34790d407ec9e2a190d576c0881a1cd78ff3c8991d1f9e40281a5ff57
+  sha256: 1aa47bd54f9e0245686d494fbbbfa4e3e77b6fc4f988708383de8a1033292e66
   patches:  # [win]
     - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch  # [win]
 


### PR DESCRIPTION
Changes:
- Update to 2.10.4

Our cbc is pinned on 2.10, and libxml2 has a run_exports on x.x, so rebuilds are not necessary.
We will have to also prepare a rebuild against the new icu, through a separate PR.

https://gitlab.gnome.org/GNOME/libxml2/-/blob/2.10/NEWS?ref_type=heads

https://gitlab.gnome.org/GNOME/libxml2/-/tree/v2.10.4?ref_type=tags