### PR TITLE
patch for CVE-2024-25062

### DIFF
--- a/recipe/0003-CVE-2024-25062.patch
+++ b/recipe/0003-CVE-2024-25062.patch
@@ -1,0 +1,29 @@
+From 2b0aac140d739905c7848a42efc60bfe783a39b7 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Sat, 14 Oct 2023 22:45:54 +0200
+Subject: [PATCH] [CVE-2024-25062] xmlreader: Don't expand XIncludes when
+ backtracking
+
+Fixes a use-after-free if XML Reader if used with DTD validation and
+XInclude expansion.
+
+Fixes #604. https://gitlab.gnome.org/GNOME/libxml2/-/issues/604
+---
+ xmlreader.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/xmlreader.c b/xmlreader.c
+index 979385a13..fefd68e0b 100644
+--- a/xmlreader.c
++++ b/xmlreader.c
+@@ -1443,6 +1443,7 @@ node_found:
+      * Handle XInclude if asked for
+      */
+     if ((reader->xinclude) && (reader->in_xinclude == 0) &&
++        (reader->state != XML_TEXTREADER_BACKTRACK) &&
+         (reader->node != NULL) &&
+ 	(reader->node->type == XML_ELEMENT_NODE) &&
+ 	(reader->node->ns != NULL) &&
+-- 
+GitLab
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,11 +7,12 @@ package:
 source:
   url: https://gitlab.gnome.org/GNOME/libxml2/-/archive/v{{ version }}/libxml2-v{{ version }}.tar.gz
   sha256: 1aa47bd54f9e0245686d494fbbbfa4e3e77b6fc4f988708383de8a1033292e66
-  patches:  # [win]
+  patches:
     - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch  # [win]
+    - 0003-CVE-2024-25062.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # remove symbols at minor versions.
     #    https://abi-laboratory.pro/tracker/timeline/libxml2/
@@ -26,10 +27,11 @@ requirements:
     - pkg-config  # [not win]
     - make      # [not win]
     - m2-patch    # [win]
+    - patch     # [unix]
   host:
-    - icu 73         # [not win]
+    - icu {{icu}}     # [not win]
     - libiconv 1.16   # [not linux]
-    - xz {{xz}}         # [not win]
+    - xz {{xz}}       # [not win]
     - zlib {{zlib}}
   run:
     - libiconv  # [not linux]


### PR DESCRIPTION
libxml2 2.10.4 on main build2

**Destination channel:** main

### Links

- [PKG-4171](https://anaconda.atlassian.net/browse/PKG-4171) 
- [Upstream repository](https://gitlab.gnome.org/GNOME/libxml2/-/issues/604)
- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2024-25062)

### Explanation of changes:
- CVE-2024-25062 is a high CVE fixed in branch 2.11 and 2.12.
- Updating to 2.11 or 2.12 would trigger a massive rebuild effort of downstream depdencies.
- Instead, this [commit](https://gitlab.gnome.org/GNOME/libxml2/-/commit/2b0aac140d739905c7848a42efc60bfe783a39b7) fix is used to patch 2.10.4 and address the vulnerability.
- diff 2.11.6 2.11.7: https://gitlab.gnome.org/GNOME/libxml2/-/compare/v2.11.6...v2.11.7?from_project_id=1665&straight=false


[PKG-4171]: https://anaconda.atlassian.net/browse/PKG-4171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ