### PR TITLE
Don't alter windows include path

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -22,10 +22,6 @@ if errorlevel 1 exit 1
 nmake /f Makefile.msvc install
 if errorlevel 1 exit 1
 
-:: For some reason the includes get put down one level.
-move %LIBRARY_INC%\libxml2\libxml %LIBRARY_INC%
-if errorlevel 1 exit 1
-
 rmdir %LIBRARY_INC%\libxml2
 del %LIBRARY_PREFIX%\bin\test*.exe || exit 1
 del %LIBRARY_PREFIX%\bin\runsuite.exe || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # remove symbols at minor versions.
     #    https://abi-laboratory.pro/tracker/timeline/libxml2/


### PR DESCRIPTION
The commit that introduced this 8 years ago doesn't say why it was introduced. It causes a patch to be required in ffmpeg, and should be removed. Conda-forge has the include path correctly nested

**Destination channel:** defaults

