### PR TITLE
v2.13.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.13.1" %}
+{% set version = "2.13.5" %}
 
 package:
   name: libxml2
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://gitlab.gnome.org/GNOME/libxml2/-/archive/v{{ version }}/libxml2-v{{ version }}.tar.gz
-  sha256: d1d90c6cecedd4a572af7aef6606bc7a1b38bcc09deef182dd065685fbd8de3f
+  sha256: 37cdec8cd20af8ab0decfa2419b09b4337c2dbe9da5615d2a26f547449fecf2a
   patches:
     - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch  # [win]
 
 build:
-  number: 2
+  number: 0
   run_exports:
     # remove symbols at minor versions.
     #    https://abi-laboratory.pro/tracker/timeline/libxml2/


### PR DESCRIPTION
libxml2 v2.13.5

**Destination channel:**  defaults

### Links

- [Upstream repository](https://gitlab.gnome.org/GNOME/libxml2/-/tree/v2.13.5?ref_type=tags)
- [Upstream changelog/diff](https://gitlab.gnome.org/GNOME/libxml2/-/compare/v2.13.1...v2.13.5?)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/lxml-feedstock/pull/15 
  - https://github.com/AnacondaRecipes/scrapy-feedstock/pull/7

### Explanation of changes:

- Bump version and SHA, reset build number. 


### Notes
- Fixes a problem in lxml when passing `utf8` encoding instead of `utf-8`