### PR TITLE
Update version to 2.14.4

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,19 +1,21 @@
 
-cd win32
+mkdir build
+cd build
 
-
-cscript configure.js compiler=msvc iconv=yes icu=no zlib=yes lzma=no python=no ^
-                     threads=ctls ^
-                     prefix=%LIBRARY_PREFIX% ^
-                     include=%LIBRARY_INC% ^
-                     lib=%LIBRARY_LIB%
+cmake -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+-D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+-D CMAKE_BUILD_TYPE=Release ^
+-D LIBXML2_WITH_ICU=no ^
+-D LIBXML2_WITH_LZMA=no ^
+-D LIBXML2_WITH_PYTHON=no ^
+-G "NMake Makefiles" ..
 
 if errorlevel 1 exit 1
 
-nmake /f Makefile.msvc
+nmake
 if errorlevel 1 exit 1
 
-nmake /f Makefile.msvc install
+nmake install
 if errorlevel 1 exit 1
 
 del %LIBRARY_PREFIX%\bin\test*.exe || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,13 @@
-{% set version = "2.13.9" %}
+{% set version = "2.14.4" %}
+{% set name = "libxml2" %}
 
 package:
-  name: libxml2
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://gitlab.gnome.org/GNOME/libxml2/-/archive/v{{ version }}/libxml2-v{{ version }}.tar.gz
-  sha256: 8d5fa142a3ea8727db1f7988b01f75b9fad8d311b8e0505e38e9d6a42a720085
+  url: https://gitlab.gnome.org/GNOME/{{ name }}/-/archive/v{{ version }}/{{ name }}-v{{ version }}.tar.gz
+  sha256: 3db82dcd8dea7861fc0b521bb1db83db221c9ed15456e0a0a8d87e451d80b675
   patches:
     - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch  # [win]
 


### PR DESCRIPTION
libxml2 2.14.4

**Destination channel:** defaults

### Links

- [PKG-12511](https://anaconda.atlassian.net/browse/PKG-12511) 
- [Upstream repository](https://gitlab.gnome.org/GNOME/libxml2/)

### Explanation of changes:
- New version number


[PKG-12511]: https://anaconda.atlassian.net/browse/PKG-12511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ