### PR TITLE
Update version to 2.14.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.14.4" %}
+{% set version = "2.14.6" %}
 {% set name = "libxml2" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://gitlab.gnome.org/GNOME/{{ name }}/-/archive/v{{ version }}/{{ name }}-v{{ version }}.tar.gz
-  sha256: 3db82dcd8dea7861fc0b521bb1db83db221c9ed15456e0a0a8d87e451d80b675
+  sha256: 673003215497c5f7666cb95374e49a33abe25480bae8029de8c0e24b0927e743
   patches:
     - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch  # [win]
 


### PR DESCRIPTION
libxml2 2.14.6

**Destination channel:** defaults

### Links

- [PKG-14767](https://anaconda.atlassian.net/browse/PKG-14767) 
- [Upstream repository](https://gitlab.gnome.org/GNOME/libxml2/)

### Explanation of changes:
- New version number


[PKG-14767]: https://anaconda.atlassian.net/browse/PKG-14767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ